### PR TITLE
Fix memzero of last array

### DIFF
--- a/src/lib/encode.c
+++ b/src/lib/encode.c
@@ -230,7 +230,7 @@ static void _LZG_SearchAccel_Init(search_accel_t* self,
     self->tab = (unsigned char**) (((hist_rec*) workingMemory) + 256);
     memset(self->tab, 0, params->window * sizeof(unsigned char**));
     self->last = self->tab + params->window;
-    memset(self->tab, 0, (fast ? 16777216 : 65536) * sizeof(unsigned char *));
+    memset(self->last, 0, (fast ? 16777216 : 65536) * sizeof(unsigned char *));
 
     /* Init parameters */
     self->params = *params;


### PR DESCRIPTION
Looks like a copy-paste error. I assume the second `memset` is supposed to initialize the last array.

It was resulting in a [crash](https://ci.appveyor.com/project/quixdb/squash/build/job/fo6r4hip5hk1tpye) in the squash tests on Win64.
